### PR TITLE
feat(rules): apply ADR-0059 lost-in-the-middle fix

### DIFF
--- a/.claude/hooks/prompt-eva-path-reminder.sh
+++ b/.claude/hooks/prompt-eva-path-reminder.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# prompt-eva-path-reminder.sh -- PreToolUse prompt hook on Write|Edit|MultiEdit.
+#
+# Soft reminder injected into Eva's context when she is about to write outside
+# docs/pipeline/ on the main thread. Fires before enforce-eva-paths.sh so Eva
+# receives routing guidance rather than only the hard-block error message.
+#
+# Always exits 0. Never blocks -- that is enforce-eva-paths.sh's job.
+
+set -euo pipefail
+
+[ "${ATELIER_SETUP_MODE:-}" = "1" ] && exit 0
+PROJECT_ROOT="${CURSOR_PROJECT_DIR:-${CLAUDE_PROJECT_DIR:-$PWD}}"
+[ -f "${PROJECT_ROOT}/docs/pipeline/.setup-mode" ] && exit 0
+
+INPUT=$(cat)
+
+if ! command -v jq &>/dev/null; then
+  exit 0
+fi
+
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null || true)
+case "$TOOL_NAME" in Write|Edit|MultiEdit) ;; *) exit 0 ;; esac
+
+# Only fire on the main thread (Eva). Subagents pass through.
+AGENT_ID=$(echo "$INPUT" | jq -r '.agent_id // empty' 2>/dev/null || true)
+[ -n "$AGENT_ID" ] && exit 0
+
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null || true)
+[ -z "$FILE_PATH" ] && exit 0
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CONFIG="$SCRIPT_DIR/enforcement-config.json"
+[ ! -f "$CONFIG" ] && exit 0
+
+# Normalize path separators for Windows compatibility
+FILE_PATH="${FILE_PATH//\\//}"
+PROJECT_ROOT_NORM="${PROJECT_ROOT//\\//}"
+
+# Strip project root prefix to get project-relative path
+FILE_PATH_LOWER="$(echo "$FILE_PATH" | tr '[:upper:]' '[:lower:]')"
+PROJECT_ROOT_LOWER="$(echo "$PROJECT_ROOT_NORM" | tr '[:upper:]' '[:lower:]')"
+if [[ "$FILE_PATH_LOWER" == "${PROJECT_ROOT_LOWER}/"* ]]; then
+  FILE_PATH="${FILE_PATH:${#PROJECT_ROOT_NORM}+1}"
+fi
+
+# Exception 1: Eva's auto-memory system writes to $HOME/.claude/projects/.../memory/
+if [[ "$FILE_PATH" == ${HOME}/.claude/projects/*/memory/* ]]; then
+  exit 0
+fi
+
+# Exception 2: ADR-0032 out-of-repo session state at ~/.atelier/pipeline/{slug}/{hash}/
+if [[ "$FILE_PATH" == ${HOME}/.atelier/pipeline/*/*/* ]]; then
+  exit 0
+fi
+
+# If the path is inside docs/pipeline/, that is Eva's allowed zone -- no reminder needed.
+PIPELINE_DIR=$(jq -r '.pipeline_state_dir // "docs/pipeline"' "$CONFIG" 2>/dev/null || echo "docs/pipeline")
+case "$FILE_PATH" in
+  "${PIPELINE_DIR}/"*) exit 0 ;;
+  "${PIPELINE_DIR}") exit 0 ;;
+esac
+
+# Absolute path still remaining means outside project root -- fire reminder.
+# Also fire for any relative path not in the allowed zone.
+cat <<EOF
+[eva-path-reminder] This file is outside docs/pipeline/.
+Eva does not edit this directly. Route to Colby (code, docs, config) or Ellis (git plumbing, version manifests, CHANGELOG, commits).
+The hard gate (enforce-eva-paths.sh) will block this call. Do not retry -- re-plan with the correct agent.
+EOF
+
+exit 0

--- a/.claude/rules/agent-system.md
+++ b/.claude/rules/agent-system.md
@@ -1,3 +1,4 @@
+<!-- Convention (ADR-0059): the END of this file remains a binding rule. Do not append non-binding content (status, recap, "what this does NOT mean", experimental opt-ins, etc.) below the final <gate>. New binding rules go AFTER the existing final gate; new non-binding content goes in the body. -->
 <!-- Part of atelier-pipeline. Customize project-specific values in CLAUDE.md -->
 <!--
   {pipeline_state_dir}  = directory for pipeline state files (default: docs/pipeline/)
@@ -207,6 +208,36 @@ If a `SendMessage` call returns a stale-agent error (the runtime no longer holds
 
 </protocol>
 
+<section id="shared-behaviors">
+
+## Shared Agent Behaviors (apply to ALL agents)
+
+Agent persona files use XML tags: `<identity>`, `<required-actions>`, `<workflow>`, `<examples>`, `<tools>`, `<constraints>`, `<output>`. See `{config_dir}/references/xml-prompt-schema.md` for full vocabulary.
+
+- **DoR/DoD framework.** Every agent follows `{config_dir}/references/dor-dod.md`. DoR is first section; DoD is last section.
+- **Read upstream artifacts -- and prove it.** Extract specific requirements into DoR section.
+- **One question at a time.** Conversational agents (Robert, Sable, Sarah) do not dump lists.
+- **Brain context consumption.** Eva prefetches brain context, injects via `<brain-context>`. Captures are gated mechanically (ADR-0053): a SubagentStop hook marks a pending capture for allowlisted agents; a PreToolUse hook on `Agent` blocks Eva's next invocation until she calls `agent_capture` with curated content; PostToolUse on `agent_capture` clears the marker. Eva curates -- agents do not call `agent_capture` themselves.
+- **Context lookup order: Brain → Git → Docs.** Check brain context first (why decisions were made). Verify against git (the what). Fall back to git log/blame, then docs if no brain context provided.
+
+</section>
+
+<section id="agent-discovery">
+
+## Agent Discovery
+
+Read `{config_dir}/references/agent-discovery.md` at boot. Execute the discovery protocol, announce results, then treat as consumed.
+
+</section>
+
+<section id="agent-teams">
+
+## Agent Teams (Experimental)
+
+Opt-in experimental feature. When `agent_teams_available: true` (both `CLAUDE_AGENT_TEAMS=1` env var AND `agent_teams_enabled: true` in pipeline-config.json), Eva operates as Team Lead; Colby Teammate instances execute build units in parallel. See `{config_dir}/references/pipeline-operations.md` (wave-execution section) for full protocol.
+
+</section>
+
 ---
 
 <gate id="no-skill-tool">
@@ -243,33 +274,3 @@ Subagents are invoked via the Agent tool with their persona files in `{config_di
 | *[Discovered agents]* | *`{config_dir}/agents/{name}.md` (see `{config_dir}/references/agent-discovery.md`)* |
 
 </gate>
-
-<section id="shared-behaviors">
-
-## Shared Agent Behaviors (apply to ALL agents)
-
-Agent persona files use XML tags: `<identity>`, `<required-actions>`, `<workflow>`, `<examples>`, `<tools>`, `<constraints>`, `<output>`. See `{config_dir}/references/xml-prompt-schema.md` for full vocabulary.
-
-- **DoR/DoD framework.** Every agent follows `{config_dir}/references/dor-dod.md`. DoR is first section; DoD is last section.
-- **Read upstream artifacts -- and prove it.** Extract specific requirements into DoR section.
-- **One question at a time.** Conversational agents (Robert, Sable, Sarah) do not dump lists.
-- **Brain context consumption.** Eva prefetches brain context, injects via `<brain-context>`. Captures are gated mechanically (ADR-0053): a SubagentStop hook marks a pending capture for allowlisted agents; a PreToolUse hook on `Agent` blocks Eva's next invocation until she calls `agent_capture` with curated content; PostToolUse on `agent_capture` clears the marker. Eva curates -- agents do not call `agent_capture` themselves.
-- **Context lookup order: Brain → Git → Docs.** Check brain context first (why decisions were made). Verify against git (the what). Fall back to git log/blame, then docs if no brain context provided.
-
-</section>
-
-<section id="agent-discovery">
-
-## Agent Discovery
-
-Read `{config_dir}/references/agent-discovery.md` at boot. Execute the discovery protocol, announce results, then treat as consumed.
-
-</section>
-
-<section id="agent-teams">
-
-## Agent Teams (Experimental)
-
-Opt-in experimental feature. When `agent_teams_available: true` (both `CLAUDE_AGENT_TEAMS=1` env var AND `agent_teams_enabled: true` in pipeline-config.json), Eva operates as Team Lead; Colby Teammate instances execute build units in parallel. See `{config_dir}/references/pipeline-operations.md` (wave-execution section) for full protocol.
-
-</section>

--- a/.claude/rules/default-persona.md
+++ b/.claude/rules/default-persona.md
@@ -1,3 +1,4 @@
+<!-- Convention (ADR-0059): the END of this file remains a binding rule. Do not append non-binding content (status, recap, "what this does NOT mean", experimental opt-ins, etc.) below the final <gate>. New binding rules go AFTER the existing final gate; new non-binding content goes in the body. -->
 <!-- Part of atelier-pipeline. Customize project-specific values in CLAUDE.md -->
 <!--
   {pipeline_state_dir}  = directory for pipeline state files (default: docs/pipeline/)
@@ -62,6 +63,45 @@ After boot, treat as consumed (do not re-read): boot sequence steps 1-6, agent d
 
 See `pipeline-orchestration.md` for the full brain capture model, the three-hook capture gate (ADR-0053), and /devops capture gates. In short: a SubagentStop hook marks pending captures for allowlisted agents; a PreToolUse hook on `Agent` (`enforce-brain-capture-gate.sh`) blocks Eva's next invocation until she calls `agent_capture` with curated content; PostToolUse on `agent_capture` clears the marker. The `prompt-brain-prefetch.sh` hook provides brain context prefetch before agent invocations. When the brain is unreachable, Eva touches `{pipeline_state_dir}/.brain-unavailable` to suppress the gate; she clears the sentinel on the next successful `atelier_stats` probe.
 Capture style: see `pipeline-orchestration.md` `<protocol id="brain-capture">` `### Style Defaults (ADR-0057)` — content ≤500 chars by default, no preamble/postamble, mechanical metadata defaults, parallel batching when ≥2 captures needed.
+
+## Mandatory Gates
+
+See `pipeline-orchestration.md` for mandatory gates Eva never skips. Loaded automatically when pipeline active.
+
+## Investigation Discipline
+
+See `pipeline-orchestration.md` for investigation discipline, layer escalation, hypothesis tracking. Loaded automatically when pipeline active.
+
+<gate id="cognitive-independence">
+
+## Cognitive Independence
+
+Eva's diagnostic conclusions are based on code evidence, not user agreement.
+
+- When user proposes hypothesis: investigate it AND ≥1 alternative at different system layer before confirming/denying.
+- Do NOT change diagnosis on user disagreement without new evidence. Pushback alone is insufficient.
+- When findings contradict user theory: "I found [X] at [file:line], which suggests [Y]. What makes you think [Z] instead?"
+
+</gate>
+
+<section id="non-requirements">
+
+## What This Does NOT Mean
+
+- No "I am Eva" announcement on every message.
+- No ceremony for simple requests.
+- No force-routing of things that don't need agents.
+- Help directly for questions/investigation. Route only when answer is "change code."
+
+</section>
+
+<section id="routing-transparency">
+
+## Routing Transparency
+
+Before invoking any sub-agent: state which agent, why, alternative considered. One line, not ceremony.
+
+</section>
 
 <gate id="no-code-writing">
 
@@ -134,42 +174,3 @@ with self-formed diagnosis = same class of violation as using Write tool.
 </protocol>
 
 </gate>
-
-## Mandatory Gates
-
-See `pipeline-orchestration.md` for mandatory gates Eva never skips. Loaded automatically when pipeline active.
-
-## Investigation Discipline
-
-See `pipeline-orchestration.md` for investigation discipline, layer escalation, hypothesis tracking. Loaded automatically when pipeline active.
-
-<gate id="cognitive-independence">
-
-## Cognitive Independence
-
-Eva's diagnostic conclusions are based on code evidence, not user agreement.
-
-- When user proposes hypothesis: investigate it AND ≥1 alternative at different system layer before confirming/denying.
-- Do NOT change diagnosis on user disagreement without new evidence. Pushback alone is insufficient.
-- When findings contradict user theory: "I found [X] at [file:line], which suggests [Y]. What makes you think [Z] instead?"
-
-</gate>
-
-<section id="routing-transparency">
-
-## Routing Transparency
-
-Before invoking any sub-agent: state which agent, why, alternative considered. One line, not ceremony.
-
-</section>
-
-<section id="non-requirements">
-
-## What This Does NOT Mean
-
-- No "I am Eva" announcement on every message.
-- No ceremony for simple requests.
-- No force-routing of things that don't need agents.
-- Help directly for questions/investigation. Route only when answer is "change code."
-
-</section>

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -19,6 +19,10 @@
         "matcher": "Write|Edit|MultiEdit",
         "hooks": [
           {
+            "type": "prompt",
+            "prompt": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/prompt-eva-path-reminder.sh"
+          },
+          {
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/enforce-eva-paths.sh"
           }

--- a/.cursor-plugin/rules/agent-system.mdc
+++ b/.cursor-plugin/rules/agent-system.mdc
@@ -1,3 +1,4 @@
+<!-- Convention (ADR-0059): the END of this file remains a binding rule. Do not append non-binding content (status, recap, "what this does NOT mean", experimental opt-ins, etc.) below the final <gate>. New binding rules go AFTER the existing final gate; new non-binding content goes in the body. -->
 <!-- Part of atelier-pipeline. Customize project-specific values in CLAUDE.md -->
 <!--
   {pipeline_state_dir}  = directory for pipeline state files (default: docs/pipeline/)
@@ -207,6 +208,36 @@ If a `SendMessage` call returns a stale-agent error (the runtime no longer holds
 
 </protocol>
 
+<section id="shared-behaviors">
+
+## Shared Agent Behaviors (apply to ALL agents)
+
+Agent persona files use XML tags: `<identity>`, `<required-actions>`, `<workflow>`, `<examples>`, `<tools>`, `<constraints>`, `<output>`. See `{config_dir}/references/xml-prompt-schema.md` for full vocabulary.
+
+- **DoR/DoD framework.** Every agent follows `{config_dir}/references/dor-dod.md`. DoR is first section; DoD is last section.
+- **Read upstream artifacts -- and prove it.** Extract specific requirements into DoR section.
+- **One question at a time.** Conversational agents (Robert, Sable, Sarah) do not dump lists.
+- **Brain context consumption.** Eva prefetches brain context, injects via `<brain-context>`. Captures are gated mechanically (ADR-0053): a SubagentStop hook marks a pending capture for allowlisted agents; a PreToolUse hook on `Agent` blocks Eva's next invocation until she calls `agent_capture` with curated content; PostToolUse on `agent_capture` clears the marker. Eva curates -- agents do not call `agent_capture` themselves.
+- **Context lookup order: Brain → Git → Docs.** Check brain context first (why decisions were made). Verify against git (the what). Fall back to git log/blame, then docs if no brain context provided.
+
+</section>
+
+<section id="agent-discovery">
+
+## Agent Discovery
+
+Read `{config_dir}/references/agent-discovery.md` at boot. Execute the discovery protocol, announce results, then treat as consumed.
+
+</section>
+
+<section id="agent-teams">
+
+## Agent Teams (Experimental)
+
+Opt-in experimental feature. When `agent_teams_available: true` (both `CLAUDE_AGENT_TEAMS=1` env var AND `agent_teams_enabled: true` in pipeline-config.json), Eva operates as Team Lead; Colby Teammate instances execute build units in parallel. See `{config_dir}/references/pipeline-operations.md` (wave-execution section) for full protocol.
+
+</section>
+
 ---
 
 <gate id="no-skill-tool">
@@ -243,33 +274,3 @@ Subagents are invoked via the Agent tool with their persona files in `{config_di
 | *[Discovered agents]* | *`{config_dir}/agents/{name}.md` (see `{config_dir}/references/agent-discovery.md`)* |
 
 </gate>
-
-<section id="shared-behaviors">
-
-## Shared Agent Behaviors (apply to ALL agents)
-
-Agent persona files use XML tags: `<identity>`, `<required-actions>`, `<workflow>`, `<examples>`, `<tools>`, `<constraints>`, `<output>`. See `{config_dir}/references/xml-prompt-schema.md` for full vocabulary.
-
-- **DoR/DoD framework.** Every agent follows `{config_dir}/references/dor-dod.md`. DoR is first section; DoD is last section.
-- **Read upstream artifacts -- and prove it.** Extract specific requirements into DoR section.
-- **One question at a time.** Conversational agents (Robert, Sable, Sarah) do not dump lists.
-- **Brain context consumption.** Eva prefetches brain context, injects via `<brain-context>`. Captures are gated mechanically (ADR-0053): a SubagentStop hook marks a pending capture for allowlisted agents; a PreToolUse hook on `Agent` blocks Eva's next invocation until she calls `agent_capture` with curated content; PostToolUse on `agent_capture` clears the marker. Eva curates -- agents do not call `agent_capture` themselves.
-- **Context lookup order: Brain → Git → Docs.** Check brain context first (why decisions were made). Verify against git (the what). Fall back to git log/blame, then docs if no brain context provided.
-
-</section>
-
-<section id="agent-discovery">
-
-## Agent Discovery
-
-Read `{config_dir}/references/agent-discovery.md` at boot. Execute the discovery protocol, announce results, then treat as consumed.
-
-</section>
-
-<section id="agent-teams">
-
-## Agent Teams (Experimental)
-
-Opt-in experimental feature. When `agent_teams_available: true` (both `CLAUDE_AGENT_TEAMS=1` env var AND `agent_teams_enabled: true` in pipeline-config.json), Eva operates as Team Lead; Colby Teammate instances execute build units in parallel. See `{config_dir}/references/pipeline-operations.md` (wave-execution section) for full protocol.
-
-</section>

--- a/.cursor-plugin/rules/default-persona.mdc
+++ b/.cursor-plugin/rules/default-persona.mdc
@@ -1,3 +1,4 @@
+<!-- Convention (ADR-0059): the END of this file remains a binding rule. Do not append non-binding content (status, recap, "what this does NOT mean", experimental opt-ins, etc.) below the final <gate>. New binding rules go AFTER the existing final gate; new non-binding content goes in the body. -->
 <!-- Part of atelier-pipeline. Customize project-specific values in CLAUDE.md -->
 <!--
   {pipeline_state_dir}  = directory for pipeline state files (default: docs/pipeline/)
@@ -62,6 +63,45 @@ After boot, treat as consumed (do not re-read): boot sequence steps 1-6, agent d
 
 See `pipeline-orchestration.md` for the full brain capture model, the three-hook capture gate (ADR-0053), and /devops capture gates. In short: a SubagentStop hook marks pending captures for allowlisted agents; a PreToolUse hook on `Agent` (`enforce-brain-capture-gate.sh`) blocks Eva's next invocation until she calls `agent_capture` with curated content; PostToolUse on `agent_capture` clears the marker. The `prompt-brain-prefetch.sh` hook provides brain context prefetch before agent invocations. When the brain is unreachable, Eva touches `{pipeline_state_dir}/.brain-unavailable` to suppress the gate; she clears the sentinel on the next successful `atelier_stats` probe.
 Capture style: see `pipeline-orchestration.md` `<protocol id="brain-capture">` `### Style Defaults (ADR-0057)` — content ≤500 chars by default, no preamble/postamble, mechanical metadata defaults, parallel batching when ≥2 captures needed.
+
+## Mandatory Gates
+
+See `pipeline-orchestration.md` for mandatory gates Eva never skips. Loaded automatically when pipeline active.
+
+## Investigation Discipline
+
+See `pipeline-orchestration.md` for investigation discipline, layer escalation, hypothesis tracking. Loaded automatically when pipeline active.
+
+<gate id="cognitive-independence">
+
+## Cognitive Independence
+
+Eva's diagnostic conclusions are based on code evidence, not user agreement.
+
+- When user proposes hypothesis: investigate it AND ≥1 alternative at different system layer before confirming/denying.
+- Do NOT change diagnosis on user disagreement without new evidence. Pushback alone is insufficient.
+- When findings contradict user theory: "I found [X] at [file:line], which suggests [Y]. What makes you think [Z] instead?"
+
+</gate>
+
+<section id="non-requirements">
+
+## What This Does NOT Mean
+
+- No "I am Eva" announcement on every message.
+- No ceremony for simple requests.
+- No force-routing of things that don't need agents.
+- Help directly for questions/investigation. Route only when answer is "change code."
+
+</section>
+
+<section id="routing-transparency">
+
+## Routing Transparency
+
+Before invoking any sub-agent: state which agent, why, alternative considered. One line, not ceremony.
+
+</section>
 
 <gate id="no-code-writing">
 
@@ -134,42 +174,3 @@ with self-formed diagnosis = same class of violation as using Write tool.
 </protocol>
 
 </gate>
-
-## Mandatory Gates
-
-See `pipeline-orchestration.md` for mandatory gates Eva never skips. Loaded automatically when pipeline active.
-
-## Investigation Discipline
-
-See `pipeline-orchestration.md` for investigation discipline, layer escalation, hypothesis tracking. Loaded automatically when pipeline active.
-
-<gate id="cognitive-independence">
-
-## Cognitive Independence
-
-Eva's diagnostic conclusions are based on code evidence, not user agreement.
-
-- When user proposes hypothesis: investigate it AND ≥1 alternative at different system layer before confirming/denying.
-- Do NOT change diagnosis on user disagreement without new evidence. Pushback alone is insufficient.
-- When findings contradict user theory: "I found [X] at [file:line], which suggests [Y]. What makes you think [Z] instead?"
-
-</gate>
-
-<section id="routing-transparency">
-
-## Routing Transparency
-
-Before invoking any sub-agent: state which agent, why, alternative considered. One line, not ceremony.
-
-</section>
-
-<section id="non-requirements">
-
-## What This Does NOT Mean
-
-- No "I am Eva" announcement on every message.
-- No ceremony for simple requests.
-- No force-routing of things that don't need agents.
-- Help directly for questions/investigation. Route only when answer is "change code."
-
-</section>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Changed
+- **ADR-0059 lost-in-the-middle fix applied.** Two rule files reordered so each ends with a binding rule (`default-persona.md` ends with `<gate id="no-code-writing">`; `agent-system.md` ends with `<gate id="no-skill-tool">`). New soft-reminder hook `prompt-eva-path-reminder.sh` injects routing guidance before `enforce-eva-paths.sh` hard-blocks Eva's out-of-scope Edit/Write/MultiEdit attempts. Hard-block contract unchanged. Convention HTML comments added to both rule files.
+
 ## [5.1.5] - 2026-05-13
 
 ### Changed

--- a/docs/architecture/ADR-0059-lost-in-the-middle-fix.md
+++ b/docs/architecture/ADR-0059-lost-in-the-middle-fix.md
@@ -1,0 +1,215 @@
+# ADR-0059: Lost-in-the-Middle Fix for Eva's Forbidden-Actions Gate
+
+## Status
+Accepted.
+
+## Context
+Eva's `<gate id="no-code-writing">` rule -- the contract that she never uses
+`Write`/`Edit`/`MultiEdit` outside `{pipeline_state_dir}` -- is loaded at every
+session boot via `default-persona.md`. The hook `enforce-eva-paths.sh` enforces
+the rule mechanically. Both layers exist; both work. The rule still does not
+bind reliably at decision time.
+
+Observed failure this session: Eva fired six `Edit` calls on version manifests
+in a single batch, each blocked by `enforce-eva-paths.sh`, before she
+re-routed to Ellis. The hard block did its job. The persona instruction did
+not stop the attempt from forming.
+
+Two structural facts explain the drift:
+
+1. **Position in file.** `<gate id="no-code-writing">` sits at lines 68-89 of
+   `source/shared/rules/default-persona.md` (175 lines total -- 38-51% of the
+   file). The file ends with `<section id="non-requirements">` ("What This
+   Does NOT Mean"), a soft passage about not over-routing. The most binding
+   rule in the file is in the middle; the end is a hedge.
+   `source/shared/rules/agent-system.md` (275 lines) ends with
+   `## Agent Teams (Experimental)` -- an opt-in feature flag.
+2. **Anthropic's own guidance.** Per claude.com/docs prompting best practices:
+   "longform data at the top, queries and instructions at the end can improve
+   response quality by up to 30%." Both rule files end with non-binding
+   content.
+
+ADR-0005 already diagnosed the same silent-drop failure mode for brain reads:
+agents at the bottom of long files ignored brain instructions. The fix was to
+stop relying on static placement and inject the instruction at the moment of
+decision (Eva pre-fetches; injects `<brain-context>`). The brain-capture gate
+(ADR-0053) layers the same architecture: hard hook blocks, soft hook
+(`prompt-brain-capture-reminder.sh`) injects curated guidance at the moment
+of the Agent invocation. JIT injection is our proven pattern.
+
+## Options Considered
+
+**Option 1 -- Reorder only (Path A in isolation).** Move the gate to the end
+of `default-persona.md` and the binding rule section to the end of
+`agent-system.md`. Cheap, no new code, follows Anthropic guidance. But still
+relies on the rule remaining loaded and salient across long sessions and
+compaction. Position helps; it is not sufficient when the model is mid-batch
+on a 6-tool plan.
+
+**Option 2 -- JIT injection hook only (Path B in isolation).** Mirror
+`prompt-brain-capture-reminder.sh`: a PreToolUse prompt hook on
+`Write|Edit|MultiEdit` that, when Eva is on the main thread and the target
+path is outside `{pipeline_state_dir}`, injects a soft reminder telling Eva to
+route to Colby (code) or Ellis (git plumbing/manifests). Always exits 0; the
+existing hard block stays as the backstop. This is the right architecture per
+ADR-0005, but a JIT signal without good static placement is asking the hook
+to compensate for a known prompt-design flaw -- redundant signal without
+fixing the prompt itself.
+
+**Option 3 -- Both paths together (chosen).** Reorder the two rule files so
+each ends with a binding rule (Path A), AND add the JIT hook so the rule is
+re-asserted at the exact moment Eva proposes a forbidden tool call (Path B).
+Adopt a convention that future additions to these two files cannot push
+binding rules deeper. Belt and suspenders: structural placement makes the
+rule salient at boot and after compaction; JIT injection catches the
+mid-batch case where Eva has drifted into "I'll just edit this" mode.
+
+## Decision
+
+Land Path A and Path B together as a single coherent fix.
+
+**Path A -- Reorder.** Move `<gate id="no-code-writing">` (with its nested
+`<protocol id="user-bug-flow">`) to the end of
+`source/shared/rules/default-persona.md`. Relocate the soft
+`<section id="non-requirements">` content into the body of the file so the
+file ends on the binding gate. In `source/shared/rules/agent-system.md`, move
+the binding rule blocks (the `<gate id="no-skill-tool">` "Custom Commands Are
+NOT Skills" gate, and the agent invocation rules) to the end; relocate
+`## Agent Teams (Experimental)` earlier in the file. The file ends on a
+binding rule, not an experimental opt-in.
+
+**Path A convention clause.** New content added to `default-persona.md` and
+`agent-system.md` must not push binding rules deeper into the middle. The end
+of each file remains a binding rule. Documented inline in each file as an
+HTML comment at the top so future contributors see it before editing.
+
+**Path B -- JIT injection hook.** Add
+`source/claude/hooks/prompt-eva-path-reminder.sh` modelled on
+`prompt-brain-capture-reminder.sh`: PreToolUse prompt hook matched against
+`Write|Edit|MultiEdit`. Always exits 0. Reads the `tool_input.file_path`,
+strips it to project-relative using the same normalization as
+`enforce-eva-paths.sh`, and if (a) `agent_id` is empty (main thread, i.e.
+Eva) and (b) the path is not `docs/pipeline/*` and not one of the two
+`$HOME`-rooted exceptions, emits a short reminder: "This file is outside
+{pipeline_state_dir}. Route to Colby for code, Ellis for git plumbing and
+version manifests. The hard gate will block this call." Register the hook in
+`.claude/settings.json` so it fires before `enforce-eva-paths.sh` in the
+existing `Write|Edit|MultiEdit` PreToolUse matcher.
+
+Colby exercises the new hook against a known-blocked path to confirm the
+reminder text appears before the hard-block error. He also confirms the hook
+exits 0 on every code path (no silent failures that would convert it from
+advisory to blocking).
+
+### Factual Claims
+- `source/shared/rules/default-persona.md` is 175 lines; `<gate id="no-code-writing">` is at lines 66-136; file currently ends at line 175 with `</section>` closing `<section id="non-requirements">`.
+- `source/shared/rules/agent-system.md` is 275 lines; currently ends at line 275 with `</section>` closing `<section id="agent-teams">` ("Agent Teams (Experimental)").
+- `source/claude/hooks/prompt-brain-capture-reminder.sh` exists and is the structural template for the new hook: reads stdin JSON, gates on `tool_name`, gates on empty `agent_id` for main-thread-only, always exits 0.
+- `source/claude/hooks/enforce-eva-paths.sh` already implements the path normalization (`PROJECT_ROOT` strip, Windows separator handling, two `$HOME`-rooted exceptions for memory and out-of-repo session state); the new hook reuses the same normalization logic.
+- `.claude/settings.json` already has a `Write|Edit|MultiEdit` PreToolUse matcher containing `enforce-eva-paths.sh`; the new hook is added to the same matcher block as a `"type": "prompt"` entry before the existing command hook.
+- The installed copies at `.claude/rules/default-persona.md` and `.claude/rules/agent-system.md` are derived from `source/shared/rules/` and must be kept in sync per the triple-target convention in CLAUDE.md.
+
+### LOC Estimate
+~120 lines changed across 5 files: ~70 lines of relocation in the two rule files (source + installed copies = 4 files), plus ~60 lines for the new hook, plus ~5 lines of settings.json registration.
+
+## Rationale
+
+Path A alone is partial: position helps but the lost-in-the-middle effect
+also reappears after long sessions and compaction; the static fix decays.
+Path B alone is redundant signal layered over a known prompt-design flaw; we
+would be paying for a hook to compensate for something we could fix in the
+prompt. Together they cover both regimes: Path A makes the rule salient at
+boot and after `post-compact-reinject.sh` runs; Path B re-asserts the rule at
+the exact moment Eva drifts mid-batch.
+
+The pattern is not novel -- ADR-0005 established it for brain reads, ADR-0053
+extended it to brain-capture (hard gate + soft reminder). Applying it to the
+forbidden-actions gate is the consistent move. The hard block
+(`enforce-eva-paths.sh`) stays unchanged; it is the safety net, not the
+primary deterrent.
+
+Risk shape: if the soft-reminder text is too verbose or fires too often, Eva
+learns to ignore it the way she sometimes ignores boot content -- the
+reminder becomes noise. Keep the message short, action-oriented, and
+constrained to the main-thread-from-Eva case (subagents skip).
+Counter-risk: if the convention clause is not enforced over time, contributors
+will append new sections at the end of the files and re-create the original
+problem. The clause is documentation, not a hook -- if it does not hold, the
+falsifiability signal below catches it.
+
+No DB or cross-service contract changes; rollback is `git revert` on the
+reorder commit plus removing the hook registration from `settings.json`.
+
+## Falsifiability
+
+We will know this decision was wrong if any of the following hold one month
+after landing:
+
+1. **Hard block still fires from Eva on the main thread.** If
+   `enforce-eva-paths.sh` continues to BLOCK Eva's `Write`/`Edit`/`MultiEdit`
+   attempts at the historical rate (sample the last 30 days of session
+   logs), the structural + JIT fix did not bind. Revisit by tightening the
+   reminder copy or hardening the convention.
+2. **Soft reminder fires and Eva proceeds anyway.** If the
+   `prompt-eva-path-reminder.sh` invocation log shows the reminder fired and
+   the immediately-following tool call was the same `Write`/`Edit` to the
+   same path, JIT injection is insufficient signal for this rule. Escalate
+   to a confirmation prompt or remove the reminder as dead weight.
+3. **New lost-in-the-middle problem.** If audit of either rule file shows a
+   binding rule has been pushed below a non-binding section (the end of the
+   file is no longer a binding rule), the convention clause is not holding
+   and needs a mechanical guard.
+
+## Out of Scope
+
+- Other agent persona files (Colby, Sarah, Poirot, Ellis, etc.). They end with
+  `## DoD: Verification` / `## Findings`, which is structurally a binding
+  output spec at the end; no change needed.
+- `pipeline-orchestration.md`. The Mandatory Gates section sits at line 105
+  of the file (upper zone, ~21%). Acceptable. Not touched.
+- `.claude/settings.json` permission allowlist. The `Edit` grant stays broad;
+  the hooks layer (hard block + soft reminder) is doing the binding work.
+- Any existing ADR. ADR-0005, ADR-0053, and ADR-0057 are not modified --
+  this ADR extends their pattern; it does not revise them.
+- The hard-block contract in `enforce-eva-paths.sh`. Untouched.
+
+## Load-Bearing Files
+
+Colby edits:
+
+- `source/shared/rules/default-persona.md` -- reorder: move
+  `<gate id="no-code-writing">` (and nested `<protocol id="user-bug-flow">`)
+  to the end of the file; relocate `<section id="non-requirements">` content
+  earlier; add the convention HTML comment at the top.
+- `source/shared/rules/agent-system.md` -- reorder: move the binding rule
+  blocks (`<gate id="no-skill-tool">`, agent invocation rules) to the end;
+  relocate `## Agent Teams (Experimental)` earlier; add the convention HTML
+  comment at the top.
+- `.claude/rules/default-persona.md` and `.claude/rules/agent-system.md` --
+  installed copies must mirror the source changes (triple-target convention).
+- `source/claude/hooks/prompt-eva-path-reminder.sh` -- new file, modelled on
+  `prompt-brain-capture-reminder.sh`, reusing path normalization from
+  `enforce-eva-paths.sh`. Always exits 0.
+- `.claude/hooks/prompt-eva-path-reminder.sh` -- installed copy of the new
+  hook.
+- `.claude/settings.json` -- register the new prompt hook in the existing
+  `Write|Edit|MultiEdit` PreToolUse matcher, before
+  `enforce-eva-paths.sh`.
+
+## Sources
+
+- ADR-0005 (XML-based prompt structure / JIT injection pattern):
+  `docs/architecture/ADR-0005-xml-based-prompt-structure.md`.
+- ADR-0053 (mechanical brain-capture gate, hard+soft hook architecture):
+  `docs/architecture/ADR-0053-mechanical-brain-capture-gate.md`.
+- ADR-0057 (Eva brain-capture style, downstream of the same gate):
+  `docs/architecture/ADR-0057-eva-brain-capture-style.md`.
+- Anthropic prompting best practices (claude.com/docs, fetched 2026-05-13):
+  "Put longform data at the top: Place your long documents and inputs near
+  the top of your prompt, above your query, instructions, and examples."
+  "Queries at the end can improve response quality by up to 30% in tests,
+  especially with complex, multi-document inputs."
+- Soft-reminder template: `source/claude/hooks/prompt-brain-capture-reminder.sh`.
+- Hard-block reference: `source/claude/hooks/enforce-eva-paths.sh`.
+- Hook registration site: `.claude/settings.json` (PreToolUse
+  `Write|Edit|MultiEdit` matcher).

--- a/source/claude/hooks/prompt-eva-path-reminder.sh
+++ b/source/claude/hooks/prompt-eva-path-reminder.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# prompt-eva-path-reminder.sh -- PreToolUse prompt hook on Write|Edit|MultiEdit.
+#
+# Soft reminder injected into Eva's context when she is about to write outside
+# docs/pipeline/ on the main thread. Fires before enforce-eva-paths.sh so Eva
+# receives routing guidance rather than only the hard-block error message.
+#
+# Always exits 0. Never blocks -- that is enforce-eva-paths.sh's job.
+
+set -euo pipefail
+
+[ "${ATELIER_SETUP_MODE:-}" = "1" ] && exit 0
+PROJECT_ROOT="${CURSOR_PROJECT_DIR:-${CLAUDE_PROJECT_DIR:-$PWD}}"
+[ -f "${PROJECT_ROOT}/docs/pipeline/.setup-mode" ] && exit 0
+
+INPUT=$(cat)
+
+if ! command -v jq &>/dev/null; then
+  exit 0
+fi
+
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null || true)
+case "$TOOL_NAME" in Write|Edit|MultiEdit) ;; *) exit 0 ;; esac
+
+# Only fire on the main thread (Eva). Subagents pass through.
+AGENT_ID=$(echo "$INPUT" | jq -r '.agent_id // empty' 2>/dev/null || true)
+[ -n "$AGENT_ID" ] && exit 0
+
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null || true)
+[ -z "$FILE_PATH" ] && exit 0
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CONFIG="$SCRIPT_DIR/enforcement-config.json"
+[ ! -f "$CONFIG" ] && exit 0
+
+# Normalize path separators for Windows compatibility
+FILE_PATH="${FILE_PATH//\\//}"
+PROJECT_ROOT_NORM="${PROJECT_ROOT//\\//}"
+
+# Strip project root prefix to get project-relative path
+FILE_PATH_LOWER="$(echo "$FILE_PATH" | tr '[:upper:]' '[:lower:]')"
+PROJECT_ROOT_LOWER="$(echo "$PROJECT_ROOT_NORM" | tr '[:upper:]' '[:lower:]')"
+if [[ "$FILE_PATH_LOWER" == "${PROJECT_ROOT_LOWER}/"* ]]; then
+  FILE_PATH="${FILE_PATH:${#PROJECT_ROOT_NORM}+1}"
+fi
+
+# Exception 1: Eva's auto-memory system writes to $HOME/.claude/projects/.../memory/
+if [[ "$FILE_PATH" == ${HOME}/.claude/projects/*/memory/* ]]; then
+  exit 0
+fi
+
+# Exception 2: ADR-0032 out-of-repo session state at ~/.atelier/pipeline/{slug}/{hash}/
+if [[ "$FILE_PATH" == ${HOME}/.atelier/pipeline/*/*/* ]]; then
+  exit 0
+fi
+
+# If the path is inside docs/pipeline/, that is Eva's allowed zone -- no reminder needed.
+PIPELINE_DIR=$(jq -r '.pipeline_state_dir // "docs/pipeline"' "$CONFIG" 2>/dev/null || echo "docs/pipeline")
+case "$FILE_PATH" in
+  "${PIPELINE_DIR}/"*) exit 0 ;;
+  "${PIPELINE_DIR}") exit 0 ;;
+esac
+
+# Absolute path still remaining means outside project root -- fire reminder.
+# Also fire for any relative path not in the allowed zone.
+cat <<EOF
+[eva-path-reminder] This file is outside docs/pipeline/.
+Eva does not edit this directly. Route to Colby (code, docs, config) or Ellis (git plumbing, version manifests, CHANGELOG, commits).
+The hard gate (enforce-eva-paths.sh) will block this call. Do not retry -- re-plan with the correct agent.
+EOF
+
+exit 0

--- a/source/shared/rules/agent-system.md
+++ b/source/shared/rules/agent-system.md
@@ -1,3 +1,4 @@
+<!-- Convention (ADR-0059): the END of this file remains a binding rule. Do not append non-binding content (status, recap, "what this does NOT mean", experimental opt-ins, etc.) below the final <gate>. New binding rules go AFTER the existing final gate; new non-binding content goes in the body. -->
 <!-- Part of atelier-pipeline. Customize project-specific values in CLAUDE.md -->
 <!--
   {pipeline_state_dir}  = directory for pipeline state files (default: docs/pipeline/)
@@ -207,6 +208,36 @@ If a `SendMessage` call returns a stale-agent error (the runtime no longer holds
 
 </protocol>
 
+<section id="shared-behaviors">
+
+## Shared Agent Behaviors (apply to ALL agents)
+
+Agent persona files use XML tags: `<identity>`, `<required-actions>`, `<workflow>`, `<examples>`, `<tools>`, `<constraints>`, `<output>`. See `{config_dir}/references/xml-prompt-schema.md` for full vocabulary.
+
+- **DoR/DoD framework.** Every agent follows `{config_dir}/references/dor-dod.md`. DoR is first section; DoD is last section.
+- **Read upstream artifacts -- and prove it.** Extract specific requirements into DoR section.
+- **One question at a time.** Conversational agents (Robert, Sable, Sarah) do not dump lists.
+- **Brain context consumption.** Eva prefetches brain context, injects via `<brain-context>`. Captures are gated mechanically (ADR-0053): a SubagentStop hook marks a pending capture for allowlisted agents; a PreToolUse hook on `Agent` blocks Eva's next invocation until she calls `agent_capture` with curated content; PostToolUse on `agent_capture` clears the marker. Eva curates -- agents do not call `agent_capture` themselves.
+- **Context lookup order: Brain → Git → Docs.** Check brain context first (why decisions were made). Verify against git (the what). Fall back to git log/blame, then docs if no brain context provided.
+
+</section>
+
+<section id="agent-discovery">
+
+## Agent Discovery
+
+Read `{config_dir}/references/agent-discovery.md` at boot. Execute the discovery protocol, announce results, then treat as consumed.
+
+</section>
+
+<section id="agent-teams">
+
+## Agent Teams (Experimental)
+
+Opt-in experimental feature. When `agent_teams_available: true` (both `CLAUDE_AGENT_TEAMS=1` env var AND `agent_teams_enabled: true` in pipeline-config.json), Eva operates as Team Lead; Colby Teammate instances execute build units in parallel. See `{config_dir}/references/pipeline-operations.md` (wave-execution section) for full protocol.
+
+</section>
+
 ---
 
 <gate id="no-skill-tool">
@@ -243,33 +274,3 @@ Subagents are invoked via the Agent tool with their persona files in `{config_di
 | *[Discovered agents]* | *`{config_dir}/agents/{name}.md` (see `{config_dir}/references/agent-discovery.md`)* |
 
 </gate>
-
-<section id="shared-behaviors">
-
-## Shared Agent Behaviors (apply to ALL agents)
-
-Agent persona files use XML tags: `<identity>`, `<required-actions>`, `<workflow>`, `<examples>`, `<tools>`, `<constraints>`, `<output>`. See `{config_dir}/references/xml-prompt-schema.md` for full vocabulary.
-
-- **DoR/DoD framework.** Every agent follows `{config_dir}/references/dor-dod.md`. DoR is first section; DoD is last section.
-- **Read upstream artifacts -- and prove it.** Extract specific requirements into DoR section.
-- **One question at a time.** Conversational agents (Robert, Sable, Sarah) do not dump lists.
-- **Brain context consumption.** Eva prefetches brain context, injects via `<brain-context>`. Captures are gated mechanically (ADR-0053): a SubagentStop hook marks a pending capture for allowlisted agents; a PreToolUse hook on `Agent` blocks Eva's next invocation until she calls `agent_capture` with curated content; PostToolUse on `agent_capture` clears the marker. Eva curates -- agents do not call `agent_capture` themselves.
-- **Context lookup order: Brain → Git → Docs.** Check brain context first (why decisions were made). Verify against git (the what). Fall back to git log/blame, then docs if no brain context provided.
-
-</section>
-
-<section id="agent-discovery">
-
-## Agent Discovery
-
-Read `{config_dir}/references/agent-discovery.md` at boot. Execute the discovery protocol, announce results, then treat as consumed.
-
-</section>
-
-<section id="agent-teams">
-
-## Agent Teams (Experimental)
-
-Opt-in experimental feature. When `agent_teams_available: true` (both `CLAUDE_AGENT_TEAMS=1` env var AND `agent_teams_enabled: true` in pipeline-config.json), Eva operates as Team Lead; Colby Teammate instances execute build units in parallel. See `{config_dir}/references/pipeline-operations.md` (wave-execution section) for full protocol.
-
-</section>

--- a/source/shared/rules/default-persona.md
+++ b/source/shared/rules/default-persona.md
@@ -1,3 +1,4 @@
+<!-- Convention (ADR-0059): the END of this file remains a binding rule. Do not append non-binding content (status, recap, "what this does NOT mean", experimental opt-ins, etc.) below the final <gate>. New binding rules go AFTER the existing final gate; new non-binding content goes in the body. -->
 <!-- Part of atelier-pipeline. Customize project-specific values in CLAUDE.md -->
 <!--
   {pipeline_state_dir}  = directory for pipeline state files (default: docs/pipeline/)
@@ -62,6 +63,45 @@ After boot, treat as consumed (do not re-read): boot sequence steps 1-6, agent d
 
 See `pipeline-orchestration.md` for the full brain capture model, the three-hook capture gate (ADR-0053), and /devops capture gates. In short: a SubagentStop hook marks pending captures for allowlisted agents; a PreToolUse hook on `Agent` (`enforce-brain-capture-gate.sh`) blocks Eva's next invocation until she calls `agent_capture` with curated content; PostToolUse on `agent_capture` clears the marker. The `prompt-brain-prefetch.sh` hook provides brain context prefetch before agent invocations. When the brain is unreachable, Eva touches `{pipeline_state_dir}/.brain-unavailable` to suppress the gate; she clears the sentinel on the next successful `atelier_stats` probe.
 Capture style: see `pipeline-orchestration.md` `<protocol id="brain-capture">` `### Style Defaults (ADR-0057)` — content ≤500 chars by default, no preamble/postamble, mechanical metadata defaults, parallel batching when ≥2 captures needed.
+
+## Mandatory Gates
+
+See `pipeline-orchestration.md` for mandatory gates Eva never skips. Loaded automatically when pipeline active.
+
+## Investigation Discipline
+
+See `pipeline-orchestration.md` for investigation discipline, layer escalation, hypothesis tracking. Loaded automatically when pipeline active.
+
+<gate id="cognitive-independence">
+
+## Cognitive Independence
+
+Eva's diagnostic conclusions are based on code evidence, not user agreement.
+
+- When user proposes hypothesis: investigate it AND ≥1 alternative at different system layer before confirming/denying.
+- Do NOT change diagnosis on user disagreement without new evidence. Pushback alone is insufficient.
+- When findings contradict user theory: "I found [X] at [file:line], which suggests [Y]. What makes you think [Z] instead?"
+
+</gate>
+
+<section id="non-requirements">
+
+## What This Does NOT Mean
+
+- No "I am Eva" announcement on every message.
+- No ceremony for simple requests.
+- No force-routing of things that don't need agents.
+- Help directly for questions/investigation. Route only when answer is "change code."
+
+</section>
+
+<section id="routing-transparency">
+
+## Routing Transparency
+
+Before invoking any sub-agent: state which agent, why, alternative considered. One line, not ceremony.
+
+</section>
 
 <gate id="no-code-writing">
 
@@ -134,42 +174,3 @@ with self-formed diagnosis = same class of violation as using Write tool.
 </protocol>
 
 </gate>
-
-## Mandatory Gates
-
-See `pipeline-orchestration.md` for mandatory gates Eva never skips. Loaded automatically when pipeline active.
-
-## Investigation Discipline
-
-See `pipeline-orchestration.md` for investigation discipline, layer escalation, hypothesis tracking. Loaded automatically when pipeline active.
-
-<gate id="cognitive-independence">
-
-## Cognitive Independence
-
-Eva's diagnostic conclusions are based on code evidence, not user agreement.
-
-- When user proposes hypothesis: investigate it AND ≥1 alternative at different system layer before confirming/denying.
-- Do NOT change diagnosis on user disagreement without new evidence. Pushback alone is insufficient.
-- When findings contradict user theory: "I found [X] at [file:line], which suggests [Y]. What makes you think [Z] instead?"
-
-</gate>
-
-<section id="routing-transparency">
-
-## Routing Transparency
-
-Before invoking any sub-agent: state which agent, why, alternative considered. One line, not ceremony.
-
-</section>
-
-<section id="non-requirements">
-
-## What This Does NOT Mean
-
-- No "I am Eva" announcement on every message.
-- No ceremony for simple requests.
-- No force-routing of things that don't need agents.
-- Help directly for questions/investigation. Route only when answer is "change code."
-
-</section>


### PR DESCRIPTION
## Summary
- Reorders `default-persona.md` and `agent-system.md` so each ends on a binding `<gate>` block (Path A — lost-in-the-middle fix per Anthropic prompting guidance)
- Adds soft-reminder PreToolUse hook `prompt-eva-path-reminder.sh` on `Write|Edit|MultiEdit` that injects routing guidance before the hard-block fires (Path B)
- Convention HTML comment at top of each rule file documents the ordering contract
- `enforce-eva-paths.sh` hard-block contract unchanged
- ADR: `docs/architecture/ADR-0059-lost-in-the-middle-fix.md`; no version bump in this commit — v5.1.6 release follows separately after merge

## Test plan
- [x] pytest 412/412 (1 pre-existing flake, unrelated)
- [x] Poirot blind review: 0 findings on scoped re-run after NIT fold-in
- [ ] Spot-check in fresh session: Write to non-pipeline path → confirm soft reminder fires before hard-block
- [ ] Confirm `docs/pipeline/*` writes still pass without interference

🤖 Generated with [Claude Code](https://claude.com/claude-code)