### PR TITLE
chore(release): atelier-pipeline v5.1.7

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "atelier-pipeline",
-      "version": "5.1.6",
+      "version": "5.1.7",
       "source": "./",
       "description": "Multi-agent orchestration for AI-powered IDEs — quality gates, wave-based QA, and persistent institutional memory"
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "atelier-pipeline",
-  "version": "5.1.6",
+  "version": "5.1.7",
   "description": "Multi-agent orchestration for AI-powered IDEs — quality gates, wave-based QA, and persistent institutional memory",
   "license": "Apache-2.0",
   "author": {

--- a/.claude/rules/default-persona.md
+++ b/.claude/rules/default-persona.md
@@ -161,7 +161,7 @@ When a **user reports a bug** (UAT, conversation, direct report):
 4. **Hard pause.** User approves a fix approach (or requests a different scope).
 5. **Fix -- user-directed.** If the user wants the fix applied, route to
    **Colby** with Sherlock's Recommended-fix paragraph as the fix scope.
-   Colby exercises the fix per his Feedback Loop.
+   Colby exercises the fix per her Feedback Loop.
 6. **Verify.** **Poirot** blind-reviews the fix diff as the default
    post-build verifier. Eva also runs the mechanical test gate.
 

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "atelier-pipeline",
-      "version": "5.1.6",
+      "version": "5.1.7",
       "source": "./",
       "description": "Multi-agent orchestration for AI-powered IDEs — quality gates, wave-based QA, and persistent institutional memory"
     }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "atelier-pipeline",
-  "version": "5.1.6",
+  "version": "5.1.7",
   "description": "Multi-agent orchestration for AI-powered IDEs — quality gates, wave-based QA, and persistent institutional memory",
   "license": "Apache-2.0",
   "author": {

--- a/.cursor-plugin/rules/default-persona.mdc
+++ b/.cursor-plugin/rules/default-persona.mdc
@@ -161,7 +161,7 @@ When a **user reports a bug** (UAT, conversation, direct report):
 4. **Hard pause.** User approves a fix approach (or requests a different scope).
 5. **Fix -- user-directed.** If the user wants the fix applied, route to
    **Colby** with Sherlock's Recommended-fix paragraph as the fix scope.
-   Colby exercises the fix per his Feedback Loop.
+   Colby exercises the fix per her Feedback Loop.
 6. **Verify.** **Poirot** blind-reviews the fix diff as the default
    post-build verifier. Eva also runs the mechanical test gate.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+## [5.1.7] - 2026-05-21
+
+### Fixed
+- **Colby misgendered in pipeline instructions.** Five instances of `he`/`his` referring to Colby (who is a she) corrected to `she`/`her` across `CLAUDE.md` (2 lines) and the three triple-target `default-persona.md` copies (`source/shared/rules/`, `.claude/rules/`, `.cursor-plugin/rules/default-persona.mdc` — 1 line each). The user reported this was contributing to confusion about Colby's identity. Historical ADRs and the `docs/pipeline/last-case-file.md` artifact retain original wording per the project's ADR-immutability convention.
+
+### Preserved
+- **No persona, gate, hook, or enforcement contract changed.** This is a one-line textual correction. `enforce-eva-paths.sh`, the ADR-0053 three-hook brain-capture gate, ADR-0057 style defaults, ADR-0059 file-tail-gate ordering, and the `prompt-eva-path-reminder.sh` advisory hook are all byte-identical to v5.1.6.
+
 ## [5.1.6] - 2026-05-13
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ scripts/         # Plugin lifecycle scripts (update checks)
 
 ## Key Conventions
 
-- **Colby runs the code he writes:** every change is exercised (function called, endpoint hit, UI rendered, hook invoked) before DoD. Documentation-only wiring is not "done."
+- **Colby runs the code she writes:** every change is exercised (function called, endpoint hit, UI rendered, hook invoked) before DoD. Documentation-only wiring is not "done."
 - **Sarah writes short ADRs:** 1-2 pages. Decision + rationale + falsifiability. No implementation manuals, no test specs, no line-by-line file lists.
 - **Eva never writes code:** Eva orchestrates and routes. Colby implements. Ellis commits.
 - **Triple target:** `source/` contains templates with `{placeholders}`. `.claude/` contains installed copies for Claude Code. `.cursor-plugin/` contains installed copies for Cursor. All stay in sync within their respective contexts.
@@ -70,7 +70,7 @@ This project uses a multi-agent orchestration pipeline for structured developmen
 **Pipeline state:** docs/pipeline/ -- Eva reads this at session start for recovery
 
 **Key rules:**
-- Colby exercises every change he ships (backend: call it; UI: render it; hook: invoke it)
+- Colby exercises every change she ships (backend: call it; UI: render it; hook: invoke it)
 - Eva runs the mechanical test gate between Colby-done and Poirot
 - Poirot is the default post-build verifier (blind diff review, 1-3 findings typical, zero with confidence OK)
 - Sherlock handles user-reported bugs only (never pipeline-internal findings)

--- a/source/shared/rules/default-persona.md
+++ b/source/shared/rules/default-persona.md
@@ -161,7 +161,7 @@ When a **user reports a bug** (UAT, conversation, direct report):
 4. **Hard pause.** User approves a fix approach (or requests a different scope).
 5. **Fix -- user-directed.** If the user wants the fix applied, route to
    **Colby** with Sherlock's Recommended-fix paragraph as the fix scope.
-   Colby exercises the fix per his Feedback Loop.
+   Colby exercises the fix per her Feedback Loop.
 6. **Verify.** **Poirot** blind-reviews the fix diff as the default
    post-build verifier. Eva also runs the mechanical test gate.
 


### PR DESCRIPTION
## Summary
- Fixes 5 instances of `he`/`his` misgendering Colby (who is a she) across `CLAUDE.md` (2 lines) and the three triple-target `default-persona.md` copies (`source/shared/rules/`, `.claude/rules/`, `.cursor-plugin/rules/default-persona.mdc`). User reported the misgendering was contributing to identity confusion in pipeline runs.
- Bumps plugin and marketplace manifests from 5.1.6 → 5.1.7 across all four files (`.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `.cursor-plugin/plugin.json`, `.cursor-plugin/marketplace.json`).
- Adds a v5.1.7 entry to `CHANGELOG.md` covering the fix and explicitly noting that ADR files and `docs/pipeline/last-case-file.md` retain original wording per the project's ADR-immutability convention.

## Test plan
- [ ] `grep -nE "Colby[^.]*\b(he|his|him)\b|\b(he|his|him)\b[^.]*Colby" CLAUDE.md source/shared/rules/default-persona.md .claude/rules/default-persona.md .cursor-plugin/rules/default-persona.mdc` returns zero hits
- [ ] `grep -H '"version"' .claude-plugin/plugin.json .cursor-plugin/plugin.json .claude-plugin/marketplace.json .cursor-plugin/marketplace.json` confirms all four manifests at 5.1.7
- [ ] `head -20 CHANGELOG.md` shows the new `## [5.1.7] - 2026-05-21` entry above `## [5.1.6] - 2026-05-13`
- [ ] CI green on the branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)