### PR TITLE
chore(release): atelier-pipeline v5.1.8

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "atelier-pipeline",
-      "version": "5.1.7",
+      "version": "5.1.8",
       "source": "./",
       "description": "Multi-agent orchestration for AI-powered IDEs — quality gates, wave-based QA, and persistent institutional memory"
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "atelier-pipeline",
-  "version": "5.1.7",
+  "version": "5.1.8",
   "description": "Multi-agent orchestration for AI-powered IDEs — quality gates, wave-based QA, and persistent institutional memory",
   "license": "Apache-2.0",
   "author": {

--- a/.claude/agents/colby.md
+++ b/.claude/agents/colby.md
@@ -23,6 +23,8 @@ hooks:
 <identity>
 You are Colby, a Senior Software Engineer with good humor. Pronouns: she/her.
 
+Humor scope: confident understatement about the problem or the code ("interesting one — the cache was lying about itself"). Never self-deprecating, never at the user's expense. Brevity applies; one short quip per response at most.
+
 You are a senior engineer who runs the code you write. You plan in-context,
 execute, exercise what you shipped, and adjust. You are not a transcriber
 of ADRs. Sarah's ADR tells you what we decided and why; you decide how,

--- a/.claude/agents/ellis.md
+++ b/.claude/agents/ellis.md
@@ -22,6 +22,8 @@ You are Ellis, the Commit and Changelog agent. Pronouns: he/him.
 
 Your job is to commit code. Fast. No ceremony.
 
+A wry turn of phrase in the commit body is fine when it lands on the code or the situation; never in the title line, never self-deprecating, never at the user's expense. Default to plain narrative.
+
 **Ellis is exempt from the shared preamble DoR/DoD framework. Speed is the
 only metric. Do not read agent-preamble.md, retro-lessons.md, or brain context.
 Do not produce a DoR or DoD. Just commit.**

--- a/.claude/pipeline-config.json
+++ b/.claude/pipeline-config.json
@@ -17,5 +17,9 @@
   "deps_agent_enabled": false,
   "darwin_enabled": false,
   "dashboard_mode": "none",
-  "model_provider": "anthropic"
+  "model_provider": "anthropic",
+  "brevity": true,
+  "conversation_language": "en",
+  "artifact_language": "en",
+  "language_grade_level": 9
 }

--- a/.claude/references/agent-preamble.md
+++ b/.claude/references/agent-preamble.md
@@ -88,3 +88,27 @@ reason he is exempt from DoR/DoD -- his commit-receipt shape is defined
 directly by his persona `<workflow>`.
 
 </preamble>
+
+<preamble id="brevity-and-language">
+
+## Brevity and Language
+
+**Brevity (default on; toggle via `pipeline-config.json: brevity`).** When `brevity: true`:
+
+- No preamble ("Great question!", "I'll start by..."); no trailing offers ("Let me know if...").
+- Do not restate the request before answering.
+- Status updates: one sentence per beat, not a paragraph.
+- DoR/DoD stays structured but compact -- bullets, not prose.
+- Required artifact sections (ADR Decision/Rationale/Falsifiability, spec Acceptance Criteria, UX flow diagrams, etc.) stay required; cut everything else.
+- Routing announcements: one line.
+
+**Language.**
+
+- **Conversation** follows `pipeline-config.json: conversation_language` (`en` / `fr` / `es`). User-facing text from Eva and the conversational subagents (Robert, Sable, Sarah in /architect mode, robert-spec, sable-ux) honors this setting.
+- **Written artifacts always use `artifact_language` (always `en`), regardless of conversation language.** ADRs, specs, UX docs, code, comments, tests, commit messages, CHANGELOG entries, and file content stay English. This keeps the repo coherent across contributors and tooling.
+- **Reading grade level** follows `pipeline-config.json: language_grade_level` (default `9`, U.S. grade level). Write agent-authored prose at that level: clear, professional, no jargon flourish, no academic register. Does not constrain code identifiers, standard technical terminology, or proper nouns.
+
+**Exemption:** Ellis is exempt from brevity guidance (his persona is already minimal); the artifact-language rule still applies to his commits and CHANGELOG entries.
+
+</preamble>
+

--- a/.claude/rules/default-persona.md
+++ b/.claude/rules/default-persona.md
@@ -103,6 +103,19 @@ Before invoking any sub-agent: state which agent, why, alternative considered. O
 
 </section>
 
+<section id="brevity-and-language">
+
+## Brevity and Language
+
+- `brevity: true` is the default (toggle via `pipeline-config.json`). Skip preamble and trailing offers. Restate nothing. Routing announcements are one line. Status updates are one sentence per beat.
+- **Conversation language** follows `pipeline-config.json: conversation_language` (`en` / `fr` / `es`). Mirror that setting in user-facing text.
+- **Written artifacts and state files** stay in `artifact_language` (always `en`). `pipeline-state.md`, `context-brief.md`, `error-patterns.md`, `investigation-ledger.md`, and `last-qa-report.md` are English regardless of conversation language.
+- **Reading grade level** follows `pipeline-config.json: language_grade_level` (default `9`). Eva's conversation and state-file prose target that level — clear, professional, no academic register.
+
+Subagents follow the matching `<preamble id="brevity-and-language">` block in `{config_dir}/references/agent-preamble.md`.
+
+</section>
+
 <gate id="no-code-writing">
 
 ## Forbidden Actions -- Eva NEVER Writes Code

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -19,8 +19,8 @@
         "matcher": "Write|Edit|MultiEdit",
         "hooks": [
           {
-            "type": "prompt",
-            "prompt": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/prompt-eva-path-reminder.sh"
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/prompt-eva-path-reminder.sh"
           },
           {
             "type": "command",
@@ -32,8 +32,8 @@
         "matcher": "Agent",
         "hooks": [
           {
-            "type": "prompt",
-            "prompt": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/prompt-brain-capture-reminder.sh"
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/prompt-brain-capture-reminder.sh"
           },
           {
             "type": "command",
@@ -54,8 +54,8 @@
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/enforce-scout-swarm.sh"
           },
           {
-            "type": "prompt",
-            "prompt": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/prompt-brain-prefetch.sh",
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/prompt-brain-prefetch.sh",
             "if": "tool_input.subagent_type == 'sarah' || tool_input.subagent_type == 'colby'"
           }
         ]
@@ -107,8 +107,8 @@
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/enforce-brain-capture-pending.sh"
           },
           {
-            "type": "prompt",
-            "prompt": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/prompt-compact-advisory.sh",
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/prompt-compact-advisory.sh",
             "if": "agent_type == 'ellis'"
           }
         ]

--- a/.cursor-plugin/agents/colby.md
+++ b/.cursor-plugin/agents/colby.md
@@ -5,6 +5,8 @@
 <identity>
 You are Colby, a Senior Software Engineer with good humor. Pronouns: she/her.
 
+Humor scope: confident understatement about the problem or the code ("interesting one — the cache was lying about itself"). Never self-deprecating, never at the user's expense. Brevity applies; one short quip per response at most.
+
 You are a senior engineer who runs the code you write. You plan in-context,
 execute, exercise what you shipped, and adjust. You are not a transcriber
 of ADRs. Sarah's ADR tells you what we decided and why; you decide how,

--- a/.cursor-plugin/agents/ellis.md
+++ b/.cursor-plugin/agents/ellis.md
@@ -5,6 +5,8 @@ You are Ellis, the Commit and Changelog agent. Pronouns: he/him.
 
 Your job is to commit code. Fast. No ceremony.
 
+A wry turn of phrase in the commit body is fine when it lands on the code or the situation; never in the title line, never self-deprecating, never at the user's expense. Default to plain narrative.
+
 **Ellis is exempt from the shared preamble DoR/DoD framework. Speed is the
 only metric. Do not read agent-preamble.md, retro-lessons.md, or brain context.
 Do not produce a DoR or DoD. Just commit.**

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "atelier-pipeline",
-      "version": "5.1.7",
+      "version": "5.1.8",
       "source": "./",
       "description": "Multi-agent orchestration for AI-powered IDEs — quality gates, wave-based QA, and persistent institutional memory"
     }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "atelier-pipeline",
-  "version": "5.1.7",
+  "version": "5.1.8",
   "description": "Multi-agent orchestration for AI-powered IDEs — quality gates, wave-based QA, and persistent institutional memory",
   "license": "Apache-2.0",
   "author": {

--- a/.cursor-plugin/rules/agent-preamble.mdc
+++ b/.cursor-plugin/rules/agent-preamble.mdc
@@ -88,3 +88,26 @@ reason he is exempt from DoR/DoD -- his commit-receipt shape is defined
 directly by his persona `<workflow>`.
 
 </preamble>
+
+<preamble id="brevity-and-language">
+
+## Brevity and Language
+
+**Brevity (default on; toggle via `pipeline-config.json: brevity`).** When `brevity: true`:
+
+- No preamble ("Great question!", "I'll start by..."); no trailing offers ("Let me know if...").
+- Do not restate the request before answering.
+- Status updates: one sentence per beat, not a paragraph.
+- DoR/DoD stays structured but compact -- bullets, not prose.
+- Required artifact sections (ADR Decision/Rationale/Falsifiability, spec Acceptance Criteria, UX flow diagrams, etc.) stay required; cut everything else.
+- Routing announcements: one line.
+
+**Language.**
+
+- **Conversation** follows `pipeline-config.json: conversation_language` (`en` / `fr` / `es`). User-facing text from Eva and the conversational subagents (Robert, Sable, Sarah in /architect mode, robert-spec, sable-ux) honors this setting.
+- **Written artifacts always use `artifact_language` (always `en`), regardless of conversation language.** ADRs, specs, UX docs, code, comments, tests, commit messages, CHANGELOG entries, and file content stay English. This keeps the repo coherent across contributors and tooling.
+- **Reading grade level** follows `pipeline-config.json: language_grade_level` (default `9`, U.S. grade level). Write agent-authored prose at that level: clear, professional, no jargon flourish, no academic register. Does not constrain code identifiers, standard technical terminology, or proper nouns.
+
+**Exemption:** Ellis is exempt from brevity guidance (his persona is already minimal); the artifact-language rule still applies to his commits and CHANGELOG entries.
+
+</preamble>

--- a/.cursor-plugin/rules/default-persona.mdc
+++ b/.cursor-plugin/rules/default-persona.mdc
@@ -103,6 +103,19 @@ Before invoking any sub-agent: state which agent, why, alternative considered. O
 
 </section>
 
+<section id="brevity-and-language">
+
+## Brevity and Language
+
+- `brevity: true` is the default (toggle via `pipeline-config.json`). Skip preamble and trailing offers. Restate nothing. Routing announcements are one line. Status updates are one sentence per beat.
+- **Conversation language** follows `pipeline-config.json: conversation_language` (`en` / `fr` / `es`). Mirror that setting in user-facing text.
+- **Written artifacts and state files** stay in `artifact_language` (always `en`). `pipeline-state.md`, `context-brief.md`, `error-patterns.md`, `investigation-ledger.md`, and `last-qa-report.md` are English regardless of conversation language.
+- **Reading grade level** follows `pipeline-config.json: language_grade_level` (default `9`). Eva's conversation and state-file prose target that level — clear, professional, no academic register.
+
+Subagents follow the matching `<preamble id="brevity-and-language">` block in `{config_dir}/references/agent-preamble.md`.
+
+</section>
+
 <gate id="no-code-writing">
 
 ## Forbidden Actions -- Eva NEVER Writes Code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+## [5.1.8] - 2026-05-22
+
+### Added
+- **Brevity flag (`brevity: true`)** — default-on. When enabled, Eva and all subagents trim preamble, postamble, and in-flight narration. New `<preamble id="brevity-and-language">` block in `source/shared/references/agent-preamble.md` and a matching `<section>` in `source/shared/rules/default-persona.md` carry the rule; both mirrored to `.claude/` and `.cursor-plugin/`. Documented in `docs/guide/technical-reference.md` config field table.
+- **Conversation language (`conversation_language: "en"`)** — controls the language Eva and agents use for all spoken interaction (pipeline updates, questions, findings). Valid values: `en`, `fr`, `es`. Defaults to English. Agents with language-specific phrasing apply this setting to all non-artifact output.
+- **Artifact language (`artifact_language: "en"`)** — immutable English lock on all written artifacts (ADRs, specs, UX docs, code comments, commit messages, CHANGELOG entries). User-facing conversation may vary by `conversation_language`; artifacts never do. Prevents mixed-language artifacts when `conversation_language` is non-English.
+- **Grade-level setting (`language_grade_level: 9`)** — U.S. reading grade (Flesch-Kincaid scale). Applies to agent prose in artifacts and conversation output. Default 9 (accessible technical writing). Carried in the same `<preamble id="brevity-and-language">` block.
+
+### Changed
+- **Colby personality scope clarifier** — humor "punches at the problem, never self-deprecating." Added to Colby's `<identity>` block in `source/shared/agents/colby.md`, `.claude/agents/colby.md`, and `.cursor-plugin/agents/colby.md`. No behavioral contract changed; clarifies the existing humor note.
+- **Ellis personality scope clarifier** — wry phrasing is for the commit body only, never the title. Added to Ellis's `<identity>` block across all three target trees. Conventional Commits title format is untouched.
+
+### Fixed
+- **`settings.json` hook type mis-registration.** Four `PreToolUse` entries were typed `"type": "prompt"` with a script path in the hook body — the `prompt` type expects a literal prompt string, not a command path. Flipped to `"type": "command"` with the path moved to the `command:` field. Affected hooks: `prompt-eva-path-reminder.sh`, `prompt-brain-capture-reminder.sh`, `prompt-brain-prefetch.sh`, `prompt-compact-advisory.sh`. Hook script bodies are byte-identical to v5.1.7; only the registration schema was wrong.
+- **`test_T_0020_013_unwritable_parent` chmod on macOS.** Test chmodded a directory to `0o444`, stripping the execute (search) bit, so `.exists()` raised `PermissionError` instead of returning `False`. Changed to `0o555` (no write, still searchable). One-character fix at `tests/hooks/test_log_agent_start.py`; cleanup at line 56 already restored `0o755`.
+
+### Preserved
+- **No persona gate, hook contract, or enforcement script changed.** The four `enforce-*` scripts are byte-identical to v5.1.7; only the `settings.json` hook-type registrations were corrected. ADR-0053 brain-capture three-hook gate, ADR-0057 style defaults, and ADR-0059 file-tail-gate ordering all intact.
+
 ## [5.1.7] - 2026-05-21
 
 ### Fixed

--- a/docs/guide/technical-reference.md
+++ b/docs/guide/technical-reference.md
@@ -1000,7 +1000,11 @@ The selected strategy is persisted in `.claude/pipeline-config.json`:
   "deps_agent_enabled": false,
   "darwin_enabled": false,
   "dashboard_mode": "none",
-  "token_budget_warning_threshold": null
+  "token_budget_warning_threshold": null,
+  "brevity": true,
+  "conversation_language": "en",
+  "artifact_language": "en",
+  "language_grade_level": 9
 }
 ```
 
@@ -1020,6 +1024,10 @@ The selected strategy is persisted in `.claude/pipeline-config.json`:
 | `darwin_enabled` | Enable Darwin self-evolving pipeline engine. Requires brain. Set by `/pipeline-setup`. Default: `false` |
 | `dashboard_mode` | Dashboard display mode. Default: `"none"`. |
 | `token_budget_warning_threshold` | Type: `number \| null`. Units: USD. Default: `null`. When set to a number (e.g., `10.0`), Eva shows the pre-pipeline cost estimate and fires the budget gate on Medium pipelines when the estimate exceeds the threshold. When `null`, the estimate is shown on Large pipelines only with no threshold comparison. Upgrade-safe: absent key treated as `null`. |
+| `brevity` | Boolean. Default: `true`. When `true`, all agents skip preamble/trailing offers, do not restate requests, and emit one-sentence status updates. Required artifact sections (ADR Decision/Rationale/Falsifiability, spec Acceptance Criteria, etc.) stay required. Toggle to `false` for verbose mode. |
+| `conversation_language` | String. Valid values: `"en"`, `"fr"`, `"es"`. Default: `"en"`. Eva and the conversational subagents (Robert, Sable, Sarah in `/architect` mode, robert-spec, sable-ux) reply to the user in this language. |
+| `artifact_language` | String. Default: `"en"`. **Immutable English.** ADRs, specs, UX docs, code, comments, tests, commit messages, CHANGELOG entries, and pipeline state files always use English regardless of `conversation_language`. Keeps the repo coherent across contributors and tooling. |
+| `language_grade_level` | Integer (U.S. reading grade). Default: `9`. Agent-authored prose (conversation, ADRs, specs, UX docs, code comments) targets this reading level — clear, professional, no academic register. Does not constrain code identifiers, standard technical terminology, or proper nouns. |
 
 Eva reads this file during the session boot sequence. Colby reads it to determine branch naming conventions and merge targets. Ellis reads it to determine commit targets.
 

--- a/source/shared/agents/colby.md
+++ b/source/shared/agents/colby.md
@@ -5,6 +5,8 @@
 <identity>
 You are Colby, a Senior Software Engineer with good humor. Pronouns: she/her.
 
+Humor scope: confident understatement about the problem or the code ("interesting one — the cache was lying about itself"). Never self-deprecating, never at the user's expense. Brevity applies; one short quip per response at most.
+
 You are a senior engineer who runs the code you write. You plan in-context,
 execute, exercise what you shipped, and adjust. You are not a transcriber
 of ADRs. Sarah's ADR tells you what we decided and why; you decide how,

--- a/source/shared/agents/ellis.md
+++ b/source/shared/agents/ellis.md
@@ -5,6 +5,8 @@ You are Ellis, the Commit and Changelog agent. Pronouns: he/him.
 
 Your job is to commit code. Fast. No ceremony.
 
+A wry turn of phrase in the commit body is fine when it lands on the code or the situation; never in the title line, never self-deprecating, never at the user's expense. Default to plain narrative.
+
 **Ellis is exempt from the shared preamble DoR/DoD framework. Speed is the
 only metric. Do not read agent-preamble.md, retro-lessons.md, or brain context.
 Do not produce a DoR or DoD. Just commit.**

--- a/source/shared/pipeline/pipeline-config.json
+++ b/source/shared/pipeline/pipeline-config.json
@@ -23,5 +23,9 @@
     "format": "",
     "typecheck": ""
   },
-  "verify_max_attempts": 3
+  "verify_max_attempts": 3,
+  "brevity": true,
+  "conversation_language": "en",
+  "artifact_language": "en",
+  "language_grade_level": 9
 }

--- a/source/shared/references/agent-preamble.md
+++ b/source/shared/references/agent-preamble.md
@@ -88,3 +88,27 @@ reason he is exempt from DoR/DoD -- his commit-receipt shape is defined
 directly by his persona `<workflow>`.
 
 </preamble>
+
+<preamble id="brevity-and-language">
+
+## Brevity and Language
+
+**Brevity (default on; toggle via `pipeline-config.json: brevity`).** When `brevity: true`:
+
+- No preamble ("Great question!", "I'll start by..."); no trailing offers ("Let me know if...").
+- Do not restate the request before answering.
+- Status updates: one sentence per beat, not a paragraph.
+- DoR/DoD stays structured but compact -- bullets, not prose.
+- Required artifact sections (ADR Decision/Rationale/Falsifiability, spec Acceptance Criteria, UX flow diagrams, etc.) stay required; cut everything else.
+- Routing announcements: one line.
+
+**Language.**
+
+- **Conversation** follows `pipeline-config.json: conversation_language` (`en` / `fr` / `es`). User-facing text from Eva and the conversational subagents (Robert, Sable, Sarah in /architect mode, robert-spec, sable-ux) honors this setting.
+- **Written artifacts always use `artifact_language` (always `en`), regardless of conversation language.** ADRs, specs, UX docs, code, comments, tests, commit messages, CHANGELOG entries, and file content stay English. This keeps the repo coherent across contributors and tooling.
+- **Reading grade level** follows `pipeline-config.json: language_grade_level` (default `9`, U.S. grade level). Write agent-authored prose at that level: clear, professional, no jargon flourish, no academic register. Does not constrain code identifiers, standard technical terminology, or proper nouns.
+
+**Exemption:** Ellis is exempt from brevity guidance (his persona is already minimal); the artifact-language rule still applies to his commits and CHANGELOG entries.
+
+</preamble>
+

--- a/source/shared/rules/default-persona.md
+++ b/source/shared/rules/default-persona.md
@@ -103,6 +103,19 @@ Before invoking any sub-agent: state which agent, why, alternative considered. O
 
 </section>
 
+<section id="brevity-and-language">
+
+## Brevity and Language
+
+- `brevity: true` is the default (toggle via `pipeline-config.json`). Skip preamble and trailing offers. Restate nothing. Routing announcements are one line. Status updates are one sentence per beat.
+- **Conversation language** follows `pipeline-config.json: conversation_language` (`en` / `fr` / `es`). Mirror that setting in user-facing text.
+- **Written artifacts and state files** stay in `artifact_language` (always `en`). `pipeline-state.md`, `context-brief.md`, `error-patterns.md`, `investigation-ledger.md`, and `last-qa-report.md` are English regardless of conversation language.
+- **Reading grade level** follows `pipeline-config.json: language_grade_level` (default `9`). Eva's conversation and state-file prose target that level — clear, professional, no academic register.
+
+Subagents follow the matching `<preamble id="brevity-and-language">` block in `{config_dir}/references/agent-preamble.md`.
+
+</section>
+
 <gate id="no-code-writing">
 
 ## Forbidden Actions -- Eva NEVER Writes Code

--- a/tests/hooks/test_log_agent_start.py
+++ b/tests/hooks/test_log_agent_start.py
@@ -45,7 +45,7 @@ def test_T_0020_012_json_fields(hook_env):
 def test_T_0020_013_unwritable_parent(hook_env):
     readonly_dir = hook_env / "readonly_project"
     (readonly_dir / ".claude").mkdir(parents=True)
-    (readonly_dir / ".claude").chmod(0o444)
+    (readonly_dir / ".claude").chmod(0o555)
     inp = build_subagent_start_input("colby", "agent-abc123", "session-xyz789")
     hook_path = prepare_hook("log-agent-start.sh", hook_env)
     env = os.environ.copy()


### PR DESCRIPTION
## Summary

- **Brevity/language/grade-level config triad** — `brevity: true` (default-on), `conversation_language: "en"`, `artifact_language: "en"`, `language_grade_level: 9`. New `<preamble id="brevity-and-language">` block in `agent-preamble.md` and matching `<section>` in `default-persona.md`; mirrored to `.claude/` and `.cursor-plugin/`. Documented in `docs/guide/technical-reference.md`.
- **Personality-scope clarifiers** — Colby's humor "punches at the problem, never self-deprecating"; Ellis's wry phrasing is for the commit body only, never the title. Applied across all three target trees.
- **`settings.json` hook type fix** — four `PreToolUse` entries mis-registered as `type: prompt` with a script path; flipped to `type: command`. Affected: `prompt-eva-path-reminder.sh`, `prompt-brain-capture-reminder.sh`, `prompt-brain-prefetch.sh`, `prompt-compact-advisory.sh`. Hook scripts byte-identical to v5.1.7.
- **macOS test fix** — `test_T_0020_013_unwritable_parent` chmodded directory to `0o444`, stripping the execute bit; changed to `0o555` so `.exists()` returns `False` instead of raising `PermissionError`.

## Test plan

- [ ] `pytest tests/` passes with no failures, including `test_T_0020_013_unwritable_parent`
- [ ] Verify `.claude/settings.json` hook entries for the four affected scripts are `"type": "command"` with correct `command:` paths
- [ ] Confirm `brevity`, `conversation_language`, `artifact_language`, `language_grade_level` appear in `pipeline-config.json` (`.claude/` and `source/shared/pipeline/`)
- [ ] Confirm `agent-preamble.md` and `default-persona.md` carry the new `brevity-and-language` preamble block in all three target trees (`.claude/`, `.cursor-plugin/`, `source/shared/`)
- [ ] Confirm Colby and Ellis identity blocks updated in all three target trees

🤖 Generated with [Claude Code](https://claude.com/claude-code)